### PR TITLE
Force UTF-8 encoding of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.0.0] - 2021-02-11
+## [0.1.0] - 2021-02-11
 
 - The first version of the client.
+
+## [0.1.2] - 2021-04-22
+
+- Fixed string encoding.

--- a/lib/logtail/log_devices/http.rb
+++ b/lib/logtail/log_devices/http.rb
@@ -201,8 +201,18 @@ MESSAGE
           req['Authorization'] = authorization_payload
           req['Content-Type'] = CONTENT_TYPE
           req['User-Agent'] = USER_AGENT
-          req.body = msgs.to_msgpack
+          req.body = msgs.map { |msg| force_utf8_encoding(msg.to_hash) }.to_msgpack
           req
+        end
+
+        def force_utf8_encoding(data)
+          if data.respond_to?(:force_encoding)
+            data.dup.force_encoding('UTF-8')
+          elsif data.respond_to?(:transform_values)
+            data.transform_values { |val| force_utf8_encoding(val) }
+          else
+            data
+          end
         end
 
         # Flushes the message buffer asynchronously. The reason we provide this

--- a/lib/logtail/version.rb
+++ b/lib/logtail/version.rb
@@ -1,3 +1,3 @@
 module Logtail
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
This function should get rid of all those incorrectly encoded strings (`[65,66,67,...]`) from all Ruby sources.

We already did the same in our Fluentd plugin: https://github.com/logtail/fluentd-plugin-logtail/blob/main/lib/fluent/plugin/out_logtail.rb#L73