### PR TITLE
Always clone tags + fix root_path on older ruby versions

### DIFF
--- a/lib/logtail/log_entry.rb
+++ b/lib/logtail/log_entry.rb
@@ -142,9 +142,9 @@ module Logtail
 
       def root_path
         if Object.const_defined?('Rails')
-          Rails.root.to_s
+          Rails.root
         elsif Object.const_defined?('Rack::Directory')
-          Rack::Directory.new('').root
+          Pathname.new(Rack::Directory.new('').root)
         else
           base_file = caller_locations.last.absolute_path
           Pathname.new(File.dirname(base_file || '/'))

--- a/lib/logtail/logger.rb
+++ b/lib/logtail/logger.rb
@@ -34,14 +34,13 @@ module Logtail
         def build_log_entry(severity, time, progname, logged_obj)
           context_snapshot = CurrentContext.instance.snapshot
           level = SEVERITY_MAP.fetch(severity)
-          tags = extract_active_support_tagged_logging_tags
+          tags = extract_active_support_tagged_logging_tags.clone
 
           if logged_obj.is_a?(Event)
             LogEntry.new(level, time, progname, logged_obj.message, context_snapshot, logged_obj,
                          tags: tags)
           elsif logged_obj.is_a?(Hash)
             # Extract the tags
-            tags = tags.clone
             tags.push(logged_obj.delete(:tag)) if logged_obj.key?(:tag)
             tags.concat(logged_obj.delete(:tags)) if logged_obj.key?(:tags)
             tags.uniq!

--- a/lib/logtail/version.rb
+++ b/lib/logtail/version.rb
@@ -1,3 +1,3 @@
 module Logtail
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
...  so that they are not cleared before the event is pushed to the server.