### PR TITLE
Fix Tagged Logging when using Rails 6

### DIFF
--- a/lib/logtail/logger.rb
+++ b/lib/logtail/logger.rb
@@ -55,7 +55,8 @@ module Logtail
 
         # Because of all the crazy ways Rails has attempted tags, we need this crazy method.
         def extract_active_support_tagged_logging_tags
-          Thread.current[:activesupport_tagged_logging_tags] ||
+          @current_tags ||
+            Thread.current[:activesupport_tagged_logging_tags] ||
             Thread.current[tagged_logging_object_key_name] ||
             EMPTY_ARRAY
         end

--- a/lib/logtail/version.rb
+++ b/lib/logtail/version.rb
@@ -1,3 +1,3 @@
 module Logtail
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
Supersedes https://github.com/logtail/logtail-ruby-rails/pull/2

I found out that accessing the `Thread.current["activesupport_tagged_logging_tags:#{object_id}"]` works in Rails 5, but doesn't work for me in Rails 6 for some reason. On the other hand, the `@current_tags` instance variable is available in Rails 6, so I took advantage of that.