### PR TITLE
Prevent logtail from raising in irb

### DIFF
--- a/lib/logtail/log_entry.rb
+++ b/lib/logtail/log_entry.rb
@@ -120,6 +120,7 @@ module Logtail
 
         calling_frame_index = last_logger_invocation_index + 1
         frame = caller_locations[calling_frame_index]
+        return {} if frame.nil?
 
         return convert_to_runtime_context(frame)
       end
@@ -138,6 +139,8 @@ module Logtail
 
       def path_relative_to_app_root(frame)
         Pathname.new(frame.absolute_path).relative_path_from(root_path).to_s
+      rescue
+        frame.absolute_path
       end
 
       def root_path

--- a/lib/logtail/version.rb
+++ b/lib/logtail/version.rb
@@ -1,3 +1,3 @@
 module Logtail
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
`relative_path_from` doesn't work for routes which don't share _any_ prefix, like `""` and `"/<anything>"` which is the case when you try logging in `irb`.