### PR TITLE
Force UTF-8 encoding for frame label 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.1.3] - 2021-06-11
 
 - Fixed detection of the frame that calls the logger.
+
+## [0.1.7] - 2021-08-16
+
+- Fixed runtime context's frame label encoding.

--- a/lib/logtail/log_entry.rb
+++ b/lib/logtail/log_entry.rb
@@ -129,9 +129,10 @@ module Logtail
         {
           file: path_relative_to_app_root(frame),
           line: frame.lineno,
-          frame_label: frame.label,
+          frame_label: frame.label.dup.force_encoding('UTF-8'),
         }
       end
+
 
       def logtail_logger_frame?(frame)
         !frame.absolute_path.nil? && frame.absolute_path.end_with?(LOGGER_FILE)

--- a/lib/logtail/log_entry.rb
+++ b/lib/logtail/log_entry.rb
@@ -133,7 +133,6 @@ module Logtail
         }
       end
 
-
       def logtail_logger_frame?(frame)
         !frame.absolute_path.nil? && frame.absolute_path.end_with?(LOGGER_FILE)
       end

--- a/lib/logtail/version.rb
+++ b/lib/logtail/version.rb
@@ -1,3 +1,3 @@
 module Logtail
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/spec/logtail/log_entry_spec.rb
+++ b/spec/logtail/log_entry_spec.rb
@@ -30,6 +30,7 @@ describe Logtail::LogEntry do
       expect(hash[:context][:runtime][:file]).to end_with('/spec/logtail/log_entry_spec.rb')
       expect(hash[:context][:runtime][:line]).to be(25)
       expect(hash[:context][:runtime][:frame_label]).to_not be_nil
+      expect(hash[:context][:runtime][:frame_label].encoding.to_s).to eq('UTF-8')
     end
   end
 end


### PR DESCRIPTION
I wasn't able to figure out why it's not converted by `Logtail.LogDevices.HTTP.force_utf8_encoding` so I went for the simplest possible fix.