### PR TITLE
Recommend executing via 'bundle exec ruby' instead of 'ruby'

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This will install all dependencies listed in the `Gemfile.lock` file.
  To run the example application, run the following command:
 
 ```bash
-ruby main.rb <source-token>
+bundle exec ruby main.rb <source-token>
 ```
 
 *Don't forget to replace `<source-token>` with your actual source token which you can find by going to logtail.com -> sources -> edit.*

--- a/example-project/README.md
+++ b/example-project/README.md
@@ -21,7 +21,7 @@ Alternatively, add `gem "logtail"` to your `Gemfile` manually and then run `bund
  To run the example application, run the following command adding your source token:
 
 ```bash
-ruby main.rb <source-token>
+bundle exec ruby main.rb <source-token>
 ```
 
 This will create a total of 5 different logs, each corresponding to a different log level. You can review these logs in Logtail.

--- a/example-project/main.rb
+++ b/example-project/main.rb
@@ -8,7 +8,7 @@ require "logtail"
 
 # Check for program arguments
 if ARGV.length != 1
-    puts "Program needs source token to run. Run the program as followed\nruby main.rb <source-token>"
+    puts "Program needs source token to run. Run the program as followed\nbundle exec ruby main.rb <source-token>"
     exit
 end
 # Create logger


### PR DESCRIPTION
Avoids possible issues with globally installed gems.