### PR TITLE
Fix TaggedLogging in Rails 7.0

### DIFF
--- a/lib/logtail/logger.rb
+++ b/lib/logtail/logger.rb
@@ -57,6 +57,10 @@ module Logtail
 
         # Because of all the crazy ways Rails has attempted tags, we need this crazy method.
         def extract_active_support_tagged_logging_tags
+          if defined?(ActiveSupport::IsolatedExecutionState)
+            @current_tags ||= ActiveSupport::IsolatedExecutionState[tagged_logging_object_key_name]
+          end
+
           @current_tags ||
             Thread.current[:activesupport_tagged_logging_tags] ||
             Thread.current[tagged_logging_object_key_name] ||

--- a/lib/logtail/version.rb
+++ b/lib/logtail/version.rb
@@ -1,3 +1,3 @@
 module Logtail
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end


### PR DESCRIPTION
In Rails 7.0, `ActiveSupport::TaggedLogging::Formatter#current_tags` uses `ActiveSupport::IsolatedExecutionStat` instead of `Thread.current`.

Should fix tests in `logtail-ruby-rails` for Rails ≥ 7.0