### PR TITLE
Update truffleruby and jruby compatibility checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,10 @@ jobs:
           - 2.4.10
           - 2.3.8
           - 2.2.10
+          - jruby-9.4.3.0
           - jruby-9.2.14.0
-          - truffleruby-21.0.0
+          - truffleruby-23.0.0
+          - truffleruby-22.1.0
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes CI checks, similar to:

https://github.com/logtail/logtail-ruby-rails/pull/20
https://github.com/logtail/logtail-ruby-rails/pull/19