### PR TITLE
Support TaggedLogging in Rails 7.1

### DIFF
--- a/lib/logtail/logger.rb
+++ b/lib/logtail/logger.rb
@@ -57,11 +57,11 @@ module Logtail
 
         # Because of all the crazy ways Rails has attempted tags, we need this crazy method.
         def extract_active_support_tagged_logging_tags
-          if defined?(ActiveSupport::IsolatedExecutionState)
-            @current_tags ||= ActiveSupport::IsolatedExecutionState[tagged_logging_object_key_name]
+          if defined?(current_tags)
+            return current_tags
           end
 
-          @current_tags ||
+          defined?(ActiveSupport::IsolatedExecutionState) && ActiveSupport::IsolatedExecutionState[tagged_logging_object_key_name] ||
             Thread.current[:activesupport_tagged_logging_tags] ||
             Thread.current[tagged_logging_object_key_name] ||
             EMPTY_ARRAY

--- a/lib/logtail/version.rb
+++ b/lib/logtail/version.rb
@@ -1,3 +1,3 @@
 module Logtail
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
 end


### PR DESCRIPTION
https://trello.com/c/CxLmTaKK/3191-clientslogtail-rack-support-rack-rack-30

TaggedLogging is being reworked in upcoming Rails 7.1, see https://github.com/rails/rails/blob/main/activesupport/lib/active_support/tagged_logging.rb

To continue to support tags in logs, `current_tags` method can be used.