### PR TITLE
L-848 Detect context.runtime using frame.absolute_path or frame.path

### DIFF
--- a/lib/logtail/log_entry.rb
+++ b/lib/logtail/log_entry.rb
@@ -134,13 +134,13 @@ module Logtail
       end
 
       def logtail_logger_frame?(frame)
-        !frame.absolute_path.nil? && frame.absolute_path.end_with?(LOGGER_FILE)
+        !frame.path.nil? && frame.path.end_with?(LOGGER_FILE)
       end
 
       def path_relative_to_app_root(frame)
         Pathname.new(frame.absolute_path).relative_path_from(root_path).to_s
       rescue
-        frame.absolute_path
+        frame.absolute_path || frame.path
       end
 
       def root_path


### PR DESCRIPTION
Sometimes, frames do not contain `absolute_path`. In such case, it's safer to use `path` instead, as it's used for suffix detection or to be displayed to user (in both cases relative path is better than nil).

Not sure which version of what component is responsible for this behavior, but I've reproduced it and verified it's fixed. It shouldn't really do any harm if the issue is not present.

Before:

<img width="918" alt="image" src="https://github.com/logtail/logtail-ruby/assets/10008612/f32e8fa0-b2f8-4315-92d3-40efc1a8f6da">

After (custom log in an included file):

<img width="919" alt="image" src="https://github.com/logtail/logtail-ruby/assets/10008612/c7af7455-8219-4578-bac4-061d69330fc9">

---

TODO after merge:

- [x] Release as 0.1.13