### PR TITLE
Update README.md: fix gem badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Better Stack dashboard](https://github.com/logtail/logtail-python/assets/10132717/e2a1196b-7924-4abc-9b85-055e17b5d499)](https://betterstack.com/logs)
 
 [![ISC License](https://img.shields.io/badge/license-ISC-ff69b4.svg)](LICENSE.md)
-[![Gem Version](https://badge.fury.io/rb/logtail-ruby.svg)](https://badge.fury.io/rb/logtail-ruby)
+[![Gem Version](https://badge.fury.io/rb/logtail.svg)](https://badge.fury.io/rb/logtail)
 [![Build Status](https://github.com/logtail/logtail-ruby/workflows/build/badge.svg)](https://github.com/logtail/logtail-ruby/actions?query=workflow%3Abuild)
 
 Experience SQL-compatible structured log management based on ClickHouse. [Learn more ⇗](https://betterstack.com/logs)


### PR DESCRIPTION
The gem we're using is called just `logtail`: https://rubygems.org/gems/logtail

There is an old duplicate gem `logtail-ruby`: https://rubygems.org/gems/logtail-ruby (last release February 16, 2021)

TODO after merge:
~Mark the logtail-ruby gem as deprecated~ There's no easy way to deprecate gem, created L-1040.