### PR TITLE
L-1040 Add deprecation notice

### DIFF
--- a/lib/logtail/logger.rb
+++ b/lib/logtail/logger.rb
@@ -186,6 +186,8 @@ module Logtail
       Logtail::Config.instance.debug { "Logtail::Logger instantiated, level: #{level}, formatter: #{formatter.class}" }
 
       @initialized = true
+
+      self.warn("The 'logtail-ruby' package has been deprecated. Please, switch to 'logtail' https://rubygems.org/gems/logtail")
     end
 
     # Sets a new formatted on the logger.

--- a/lib/logtail/version.rb
+++ b/lib/logtail/version.rb
@@ -1,3 +1,3 @@
 module Logtail
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/logtail.gemspec
+++ b/logtail.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/logtail/logtail-ruby"
   spec.license       = "ISC"
 
-  spec.summary       = "Query logs like you query your database. https://logtail.com"
+  spec.summary       = "This package has been deprecated. Please, switch to 'logtail' https://rubygems.org/gems/logtail"
 
   spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
   spec.metadata["changelog_uri"] = "#{spec.homepage}/tree/master/CHANGELOG.md"


### PR DESCRIPTION
Targets 63a7be2 (`0.1.2`, last version released on https://rubygems.org/gems/logtail-ruby)

Creating this PR just for review purposes, not planning to merge, just push to Rubygems.org.