### PR TITLE
Use TruffleRuby 23.1.2 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           - "2.5"
           - "jruby-9.4.3.0"
           - "jruby-9.2.14.0"
-          - "truffleruby-23.0.0"
+          - "truffleruby-23.1.2"
           - "truffleruby-22.1.0"
 
     steps:


### PR DESCRIPTION
Seems like sqlite3 2.6.0 doesn't play nicely with truffleruby-23.0.0...

Success: https://github.com/logtail/logtail-ruby/actions/runs/13363612570/job/37317269098
Failure: https://github.com/logtail/logtail-ruby/actions/runs/13491501826/job/37690365009

Updating TruffleRuby 23 to latest version (23.1.2 from Jan 16, 2024) ~fixes the build issue~.