### PR TITLE
CI: Drop unused dev dependency on sqlite

### DIFF
--- a/logtail.gemspec
+++ b/logtail.gemspec
@@ -34,10 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rspec-its', '>= 0')
   spec.add_development_dependency('timecop', '>= 0')
   spec.add_development_dependency('webmock', '~> 2.3')
-
-  if RUBY_PLATFORM == "java"
-    spec.add_development_dependency('activerecord-jdbcsqlite3-adapter', '>= 0')
-  else
-    spec.add_development_dependency('sqlite3', '>= 0')
-  end
 end


### PR DESCRIPTION
I couldn't find any usage of sqlite in our tests, so unsure why it was marked as development dependency 🤔 

Removing it should make the truffleruby-23.0.0 CI test succeed, see https://github.com/logtail/logtail-ruby/pull/35