### PR TITLE
Fix incorrect statement about not dropping logs by default

### DIFF
--- a/lib/logtail/log_devices/http.rb
+++ b/lib/logtail/log_devices/http.rb
@@ -30,10 +30,8 @@ module Logtail
       # options control when the flush happens, `:batch_byte_size` and `:flush_interval`.
       # If either of these are surpassed, the buffer will be flushed.
       #
-      # By default, the buffer will apply back pressure when the rate of log messages exceeds
-      # the maximum delivery rate. If you don't want to sacrifice app performance in this case
-      # you can drop the log messages instead by passing a {DroppingSizedQueue} via the
-      # `:request_queue` option.
+      # By default, the buffer will drop log messages when the rate of log messages exceeds
+      # the maximum delivery rate. You can change this with the `:request_queue` option.
       #
       # @param source_token [String] The API key provided to you after you add your source to
       #   [Better Stack](https://telemetry.betterstack.com).


### PR DESCRIPTION
We're seeing issues with logs dropping. Based on a (too) quick read of this source code I thought the logger gem was not the issue, but on a second read I noticed this description is incorrect and contradicts the `:request_queue` documentation:
https://github.com/logtail/logtail-ruby/blob/b5f0773a9ee8831f0288ed098e71b0537ba3971e/lib/logtail/log_devices/http.rb#L56-L61