### PR TITLE
Update GitHub Actions runner to use ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
           - "2.7"
           - "2.6"
           - "2.5"
-          - "jruby"
           - "truffleruby"
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,8 @@ jobs:
           - "2.7"
           - "2.6"
           - "2.5"
-          - "jruby-9.4.3.0"
-          - "jruby-9.2.14.0"
-          - "truffleruby-23.0.0"
-          - "truffleruby-22.1.0"
+          - "jruby"
+          - "truffleruby"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Our Github Actions stopped running because we were using unsupported runner version.

<img width="1277" height="312" alt="image" src="https://github.com/user-attachments/assets/bf4ce8ea-ef74-465e-9c39-0d8afa85b0d5" />

<img width="1328" height="133" alt="image" src="https://github.com/user-attachments/assets/5609237b-238f-456a-8ae2-66c59728c088" />
